### PR TITLE
Refine dashboard CLI command and token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Or deploy to production from ansible folder
 
 Or use the `deploy.sh` to keep the compatibility with old Java and Wildfly
 
+## Dashboard update from command line
+
+You can run dashboard update directly from CLI:
+
+    YOUTRACK_TOKEN=<token> lein run update-dashboards-on-server
+
+For Kubernetes scheduled runs, apply:
+
+    kubectl apply -f kubernetes/todoist-sync-dashboard-update-cronjob.yaml
+
 ## Start in dev-mode
 
 `-Dconfig.file=application-dev.conf`

--- a/kubernetes/k8s.md
+++ b/kubernetes/k8s.md
@@ -1,4 +1,3 @@
-
     minikube image load todoist-sync
 
 ## Update on kubernetes
@@ -10,3 +9,10 @@
 
 2. Update deployment
    you could simply delete the pod and let it be recreated by the deployment
+
+3. Apply dashboard update CronJob
+
+    kubectl apply -f kubernetes/todoist-sync-dashboard-update-cronjob.yaml
+
+The CronJob runs the CLI command `update-dashboards-on-server`.
+Set interval via `.spec.schedule` and make sure `todoist-sync-secrets` contains `YOUTRACK_TOKEN`.

--- a/kubernetes/todoist-sync-dashboard-update-cronjob.yaml
+++ b/kubernetes/todoist-sync-dashboard-update-cronjob.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: todoist-sync-dashboard-update
+  labels:
+    app: todoist-sync
+spec:
+  # Change this value to the required interval.
+  schedule: "*/30 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app: todoist-sync
+        spec:
+          restartPolicy: Never
+          imagePullSecrets:
+            - name: space-registry
+          containers:
+            - name: dashboard-update
+              image: registry.jetbrains.team/p/td-sync/containers/td-sync:latest
+              imagePullPolicy: Always
+              args:
+                - update-dashboards-on-server
+              env:
+                - name: YOUTRACK_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: todoist-sync-secrets
+                      key: YOUTRACK_TOKEN

--- a/src/todoist_sync/core.clj
+++ b/src/todoist_sync/core.clj
@@ -5,6 +5,7 @@
             [todoist-sync.todoist :as tdst]
             [todoist-sync.texts-handler :as thd]
             [todoist-sync.workflow :as workflow]
+            [todoist-sync.workdash :as workdash]
             [ring.util.response :as rur]
             [ring.adapter.jetty :as jetty]
             [ring.middleware.cookies :refer [wrap-cookies]]
@@ -167,8 +168,20 @@
 
 (defn -main
   [& args]
-  ;; Clean up on startup
-  (println "Cleaning up old export files...")
-  (cleanup-old-files 2)
-  
-  (jetty/run-jetty app {:port 3000}))
+  (let [cli-command (first args)
+        dashboard-update-command? (= "update-dashboards-on-server" cli-command)]
+    (if dashboard-update-command?
+      (if-let [yt-token (not-empty (System/getenv "YOUTRACK_TOKEN"))]
+        (do
+          (println "Running dashboard update in CLI mode...")
+          (workdash/update-dashboards-on-server yt-token)
+          (println "Dashboard update finished."))
+        (do
+          (binding [*out* *err*]
+            (println "YOUTRACK_TOKEN is required for CLI dashboard update mode."))
+          (System/exit 1)))
+      (do
+        ;; Clean up on startup
+        (println "Cleaning up old export files...")
+        (cleanup-old-files 2)
+        (jetty/run-jetty app {:port 3000})))))


### PR DESCRIPTION
### Motivation

- Simplify the CLI entrypoint for running dashboard updates by removing unnecessary aliases and keeping a single explicit command.
- Enforce a single, clearly-named environment variable for authentication to make fail-fast behavior predictable in CI/Kubernetes.
- Ensure the Kubernetes CronJob and documentation match the simplified CLI and token handling.

### Description

- Tightened `-main` in `src/todoist_sync/core.clj` to accept only the `update-dashboards-on-server` CLI command and to call `workdash/update-dashboards-on-server` when invoked.
- Switched token lookup to use only the `YOUTRACK_TOKEN` environment variable and updated the CLI error message to `YOUTRACK_TOKEN is required for CLI dashboard update mode.` with a fail-fast `System/exit 1` on missing token.
- Added the `todoist-sync.workdash` require and preserved the original web server startup path when the CLI command is not used.
- Updated `kubernetes/todoist-sync-dashboard-update-cronjob.yaml` to invoke `update-dashboards-on-server` and to read `YOUTRACK_TOKEN` from the `todoist-sync-secrets` Secret, and updated `kubernetes/k8s.md` to document the new command and secret requirement.

### Testing

- Ran the test suite with `lein test`, which completed successfully (`11 tests`, `46 assertions`, `0 failures`, `0 errors`).
- Executed the CLI validation `lein run update-dashboards-on-server` and verified it exits with code `1` and prints the expected missing-token error when `YOUTRACK_TOKEN` is not provided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1090d9b0832f81c05a6455fd393d)